### PR TITLE
Extract errors into errors ns

### DIFF
--- a/src/bean/code_errors.cljs
+++ b/src/bean/code_errors.cljs
@@ -1,0 +1,4 @@
+(ns bean.code-errors)
+
+(defn named-ref-error [named error]
+  (str "name: " named ". " error))

--- a/src/bean/errors.cljs
+++ b/src/bean/errors.cljs
@@ -1,8 +1,38 @@
 (ns bean.errors)
 
+(defn reset [value]
+  (dissoc value :error))
+
+(defn mark [value error]
+  (merge value error))
+
+(defn get-error [{:keys [error]}]
+  error)
+
 (defn undefined-named-ref [name]
   {:error (str "Undefined reference: \"" name "\"")
    :representation (str "Undefined reference: \"" name "\"")})
 
-(defn named-ref-error [named error]
-  (str "name: " named ". " error))
+(defn spill-error []
+  {:error "Spill error"
+   :representation "Spill error"})
+
+(defn stringified-error
+  "This exists to funnel all usages of automatically stringified errors
+   centrally. We should eventually remove this and have more explicit
+   representations for each error."
+  [e]
+  {:error e
+   :representation (str e)})
+
+(defn matrix-size-mismatch-error []
+  {:error "Matrices should be same size."
+   :representation "Matrices should be same size."})
+
+(defn type-mismatch-+-op []
+  {:error "+ only works for Integers"
+   :representation "+ only works for Integers"})
+
+(defn type-mismatch-*-op []
+  {:error "* only works for Integers"
+   :representation "* only works for Integers"})

--- a/src/bean/operators.cljs
+++ b/src/bean/operators.cljs
@@ -1,11 +1,12 @@
-(ns bean.operators)
+(ns bean.operators
+  (:require [bean.errors :as errors]))
 
 (defn bean-op-+ [left right]
   (if (and (int? left) (int? right))
     (+ left right)
-    {:error "+ only works for Integers"}))
+    (errors/type-mismatch-+-op)))
 
 (defn bean-op-* [left right]
   (if (and (int? left) (int? right))
     (* left right)
-    {:error "* only works for Integers"}))
+    (errors/type-mismatch-*-op)))

--- a/src/bean/provenance.cljs
+++ b/src/bean/provenance.cljs
@@ -1,6 +1,7 @@
 (ns bean.provenance
   (:require [bean.util :as util]
-            [bean.interpreter :as interpreter]))
+            [bean.interpreter :as interpreter]
+            [bean.errors :as errors]))
 
 (defn- value-proof [v & args]
   (->> args
@@ -25,8 +26,8 @@
                 #(value-proof (get-in matrix (conj %1 :value)) %2 op rproof)
                 lmatrix)}
       rmatrix {:matrix (util/map-on-matrix-addressed
-                #(value-proof (get-in matrix (conj %1 :value)) lproof op %2)
-                rmatrix)}
+                        #(value-proof (get-in matrix (conj %1 :value)) lproof op %2)
+                        rmatrix)}
       :else (value-proof value lproof op rproof))))
 
 (declare cell-proof)
@@ -79,9 +80,8 @@
    A proof is a vector of the shape [proof-type proof & dependency-proofs].
   `dependency-proofs` is a list of proofs."
   [address {:keys [grid] :as sheet}]
-  (let [cell (util/get-cell grid address)
-        error? (:error cell)]
-    (when-not error?
+  (let [cell (util/get-cell grid address)]
+    (when-not (errors/get-error cell)
       (if (:spilled-from cell)
         (spilled-cell-proof address cell sheet)
         [:cell-ref

--- a/test/bean/operators_test.cljs
+++ b/test/bean/operators_test.cljs
@@ -1,9 +1,19 @@
 (ns bean.operators-test
-  (:require [bean.operators :refer [bean-op-+]]
+  (:require [bean.operators :refer [bean-op-+ bean-op-*]]
             [clojure.test :refer [deftest testing is]]))
 
 (deftest bean-op-+-test
   (testing "Adds two numbers"
     (is (= (bean-op-+ 2 3) 5)))
   (testing "Returns an error if an operand is an invalid data type"
-    (is (= (bean-op-+ "1" 2) {:error "+ only works for Integers"}))))
+    (is (= (bean-op-+ "1" 2) {:error "+ only works for Integers"
+                              :representation "+ only works for Integers"}))))
+
+(deftest bean-op-*-test
+  (testing "Multiplies two numbers"
+    (is (= (bean-op-* 2 3) 6)))
+  (testing "Returns an error if one operand is a string"
+    (is (= (bean-op-* 1 "2") {:error "* only works for Integers"
+                              :representation "* only works for Integers"}))
+    (is (= (bean-op-* "1" 2) {:error "* only works for Integers"
+                              :representation "* only works for Integers"}))))


### PR DESCRIPTION
The intention is to move to a state of code where error types are represented with symbols instead of strings and that they always accompany the error's human-readable string `:representation`. This should happen in future commits.

This commit also:
- Add some basic tests for the * operator.
- Extract code-errors from the errors ns
- Move some errors mark/reset/get code into the errors ns